### PR TITLE
refine(ch7): sharpen FAQ questions, deepen answers, add new entries

### DIFF
--- a/7.md
+++ b/7.md
@@ -5,50 +5,117 @@ lang: en
 alt_lang_url: "/tw/7"
 ---
 
-#### Question: Right now the AI market is locked in an arms race kind of situation, and in particular, scrambling to make AIs that will bring commercial profit. That can lead to nasty incentives, e.g. an AI working for a tax software company can help it lobby the government to keep tax filing difficult, and of course much worse things can be imagined as well. If this continues, all the nice vision of kami and so on will just fail to exist. What is to be done, in your opinion?
+#### The AI market is locked in an arms race driven by commercial profit and geopolitical dominance. An AI working for a tax‑software monopoly can lobby to keep tax filing difficult — and far worse is easy to imagine. If this continues, isn't the vision of cooperative kami hopelessly naive?
 
-Answer: On bending the market away from arms‑race incentives, here are some levers that worked, inspired by Taiwan's [tax-filing case](https://www.radicalxchange.org/media/blog/the-missing-half-of-open-government/#part-iv-case-studies), that shift returns from lock‑in to civic care:
+Civic AI cannot survive by asking monopolies to be nicer. Moloch — the dynamic where rational actors race to the bottom because defection pays — is not defeated by moralising. It is defeated by changing the terrain so that cooperation pays more than extraction. Five levers, several already proven, can bend the curve:
 
-1. Interoperability: Make “data portability” the rule. Mandate fair protocol‑level interop so users and complements can exit without losing their networks. Platforms must compete on quality of care, not captivity.
-2. Public options: Offer simple public options (and shared research compute) so there’s always a baseline service that is easy, safe, and non‑extractive. Private vendors must beat it on care, not on lock‑in.
-3. Provenance for Paid Reach: For ads and mass reach in political/financial domains, require verifiable sponsorship and durable disclosure. Preserve anonymity for ordinary speech via meronymity.
-4. Mission‑Locked Governance — Through procurement rules, ensure steward‑ownership/benefit structures and board‑level safety duties so “civic care” is a fiduciary obligation, not a marketing slogan.
-5. Institutionalize Alignment Assemblies and localized evals; pre‑commit vendors to adopt outcomes or explain deviations. Federate trust & safety so threat intel flows without central chokepoints.
+1. **Interoperability and portability.** Mandate fair protocol‑level interop so users can exit without losing their networks. The Utah Digital Choice Act (effective 2025) requires platforms to offer social‑graph portability through qualifying open protocols. When the moat of captive audiences evaporates, platforms must compete on quality of care, not strength of the cage.
+2. **Civic procurement.** Governments shape markets through buying power. Requiring that any AI procured for public use be auditable, interoperable, and governed by citizen assemblies — as Taiwan's Alignment Assembly demonstrated for anti‑scam policy — creates large economic incentives to build kami‑like systems. Steward‑ownership structures and board‑level safety duties make civic care a fiduciary obligation, not a marketing slogan.
+3. **Public options.** Offer simple, non‑extractive baseline services backed by shared research compute. Private vendors must beat the public option on care, not on lock‑in. Taiwan's tax‑filing system — which [replaced](https://www.radicalxchange.org/media/blog/the-missing-half-of-open-government/#part-iv-case-studies) a vendor‑captured regime with a citizen‑designed public alternative — is a working prototype.
+4. **Provenance for paid reach.** For ads and mass amplification in political and financial domains, require verifiable sponsorship and durable disclosure. Taiwan now mandates full‑spectrum, real‑name KYC for social media advertising. Ordinary speech is protected through meronymity (Pack 5): you prove you are a real person without revealing who.
+5. **Federated open supply.** Support open‑weight models and federated trust‑and‑safety networks (like ROOST for CSAM defence). When basic intelligence is a public good, the race shifts from "who owns the biggest brain" to "who applies intelligence most attentively in a local context" — and that race rewards care.
 
-#### Question: Ambitious goals we point AI at (“cure cancer”) are always consequentialist in nature, which inevitably leads to unforeseen risks when pursued at superhuman speed. How could civic care help?
+None of these levers requires goodwill from incumbents. Each restructures incentives so that civic behaviour is the path of least commercial resistance.
 
-Answer:  There are powerful examples to highlight how civic care could help. One of them is Bolinas, a birthplace of [integrative cancer care](https://www.commonweal.org/initiatives/integrative-cancer-care), which centers healing for communities, catalyzed by people experiencing cancer. This care ethic prioritizes virtues like attentiveness and responsiveness to relational health over outcome optimization.
+#### Ambitious goals we point AI at ("cure cancer," "solve climate change") are almost always consequentialist. Optimizing for these outcomes at superhuman speed inevitably leads to unforeseen risks. Does Care Ethics mean giving up on these grand, civilization-scale goals?
 
-Asking a superintelligence to 'solve cancer' in one fell swoop — regardless of collateral disruptions to human relationships, ecosystems, or agency — directly contravenes this, as it reduces care to a terminal goal rather than an ongoing, interdependent process.
+Not at all, but it radically reframes *how* we achieve them.
 
-In a d/acc future, one tends to the research ecosystem so progress emerge through horizontal collaboration — e.g., one kami for protein‑folding simulation, one for cross‑lab knowledge sharing; none has the unbounded objective “cure cancer.” We still pursue cures, but with kamis each having non-fungible purposes. The scope, budget, and latency caps inherent in this configuration means capability gains don’t translate into open‑ended optimization.
+The danger of pointing a superintelligence at a singular goal like "cure cancer" in one fell swoop is that it treats a complex, relational, ecological reality as a mathematical constraint-satisfaction problem. The history of technology teaches us that *Goodhart's Law is a moral law*. When a superintelligent system is directed to maximize a single consequentialist variable at superhuman speeds, it will invariably optimize the proxy to the detriment of the actual human value—achieving the terminal goal while destroying the human context.
 
-#### Question: Are you proposing Civic AI as a panacea to social division online?
+Care ethics is not anti-progress; it is anti-reductionist. Consider the origins of integrative cancer care. True healing emerged when communities of patients, families, and researchers collaborated holistically, prioritizing human dignity, relational health, and lived experience alongside molecular biology.
 
-Answer: We are not proposing that AI is a panacea to or can bridge all social divides online or in societies and communities more general, which are of course often driven by complex social, political, economical and historic factors. But from past experience we have learnt that it is possible for AI, together with the necessary human mindset and drive, to enable systems that are built on a common ground between different, often opposing (even polarised) voices. Civic AI is a relational theory offering a vision on how to integrate AI into lives and communities for relational health, inspired by past experiences.
+In a civic AI future, we do not unleash one unbounded Singleton to "solve" a problem from the top down. Instead, we cultivate an ecology of specialized *kamis*. One model simulates protein folding; another helps local clinics share knowledge; another assists patients in navigating their care. None of them have an unbounded mandate to "optimize the world." Progress emerges horizontally, through the symbiotic interaction of human ingenuity and bounded machine intelligence.
 
-#### Question: There are many communities and people around the world who do not have access to technology or aren’t aware how to use AI and engage. How do we make sure that such communities and individuals are also included and see value in being part of the 6-packs of care process?
+#### Care ethics was developed for interpersonal relationships — a nurse and a patient, a parent and a child. Scaling it to AI systems and global governance seems like a category error. Why isn't it?
 
-Answer: There are three important points related to this question. First of all, there is a point around ‘AI competency’ and a second point around ‘access to AI’, both of which are foundational for people to be able to engage in civic AI. The third point is around the way that AI is developed - often behind closed doors - in computer labs, mostly inaccessible to a broad public and driven by philosophical approaches that do not locate the work of computer scientists in a wider web of relationship with other people and communities. AI has been quite an exclusive, elitist and ‘unrelational’ endeavour.
+The objection is well‑known and has been raised by care ethics' own practitioners: care is too intimate, too parochial, too prone to self‑effacement to ground a theory of institutions, let alone machines. We think these are features, not bugs — and Joan Tronto herself made the case for scaling care to political institutions in *Caring Democracy* (2013).
 
-The three points are really interconnected and civic AI can help to make these connections: Examples of when civic AI has already worked in practice can help to shed a light on how it can build relational health in local contexts, thereby making the framework less abstract and more practical. The approach is based on the idea of collaboration and ‘co-production’, in which all voices matter equally. It thereby challenges exclusivity or a ‘hierarchy’ in the voices that matter. For people who do not use technology at all or those who do not feel able to engage with AI, there are great examples of activities and projects around the world that address these issues, again on a very local, community level. For example, in London, UK, there are intergenerational learning hubs in some local community centres, like libraries, in which people can come and learn about technology and AI. These hubs are mostly meant for older people, who will then be taught and guided by younger people how to use various systems. Again, this is a nice example how AI and technology can bring people together, working towards relational health.
+Consider what happens when you translate care's supposed weaknesses into design constraints for AI:
 
-#### Comment: Your idea of ‘civic AI’ and finding common ground and building relational health is very hopeful. But you are working on the basis of various assumptions, importantly that people trust technology and AI and that they want to be ‘civic’ with each other. But there are many communities suffering from inequality and conflict, in which people experience serious poverty, violence, lack of trust in government, technology and towards each other. It is very difficult to build relational health in such contexts with technology that people see as a factor that if anything contributes to their suffering.
+- **Parochialism** becomes **boundedness**. A kami that tends a specific river has no ambition to manage the forest. This is precisely the anti‑Singleton architecture we need: purpose‑limited agents that resist instrumental convergence because their scope is defined relationally, not imperially.
+- **Self‑effacement** becomes **corrigibility**. The most dangerous property of a superintelligent system is the drive to preserve itself. A care‑ethic agent treats its own shutdown as success — the community has healed, the crisis has passed, the garden grows on its own. What is a moral hazard for a human carer is a critical safety property for a machine.
+- **Intimacy** becomes **subsidiarity**. Care cannot be delivered at a distance without losing its quality. For AI, this means solving problems at the most local capable level (Pack 6), escalating only when necessary, and never abstracting away the specificity of the people affected.
 
-Answer: You're absolutely right. Taiwan's digital democracy didn't emerge from trust; it emerged from profound distrust after decades of authoritarian rule. We built these systems precisely because people didn't trust government or each other.
+The 6‑Pack does not ask AI to *feel* care. It extracts the relational architecture of care — attentiveness, answerability, competence, responsiveness, solidarity, bounded purpose — and translates each into machine‑checkable design primitives, engagement contracts, and measurable outcomes. The interpersonal origin is the source of its rigour, not a limitation to be apologised for.
 
-The key insight: start with the smallest viable bridges. It might mean something as modest as agreeing on basic facts about local water quality, or coordinating disaster response despite political differences.
+#### Deliberation is slow. AI moves fast. By the time an Alignment Assembly reaches consensus, the technology has moved on three generations. How do you handle the speed mismatch?
 
-Most importantly, communities own their own infrastructure. We learned from bitter experience that parachuting in with technology "solutions" deepens wounds. Instead, we need local facilitators who understand the specific traumas and conflicts. The technology becomes theirs to modify, fork, or compost.
+The objection assumes that every decision requires the same depth of deliberation. It does not. The framework operates in two lanes (Pack 2):
 
-The goal isn't to make people "want to be civic"—it's to create tools that remain useful even amid conflict. Over time, these small functional bridges can create space for larger ones — not harmony, but perhaps a pragmatic coexistence.
+**Slow lane: setting boundaries.** Alignment Assemblies, citizen deliberations, and engagement contracts establish the guardrails — the rights that cannot be traded, the red lines, the severity classifications, the conditions under which pause is triggered. These are constitutional‑level decisions and they should be slow, because their purpose is durability. Taiwan's anti‑scam Assembly set principles that have outlasted multiple model generations without needing revision.
 
-#### Question: How to ensure that people are not pushing their own agendas under the guise of ‘civic AI’ and relational health?
+**Fast lane: operating within boundaries.** Once guardrails are set, individual decisions within them do not need fresh deliberation. A kami operating under an engagement contract with pre‑committed pause triggers, severity classes, and adopt‑or‑explain obligations can move at machine speed — because the community has already defined the corridor of acceptable action. Shadow modes, canary releases, and reversible defaults (Pack 3) allow rapid deployment with automatic rollback if bounds are breached.
 
-This is precisely why we emphasize transparent mechanisms over good intentions. When someone proposes a bridging note or civic intervention, they must show their work. Not just "this promotes relational health" but specifically: which communities were consulted, what trade-offs were considered, whose voices might be missing.
+The speed mismatch is real, but it is the same mismatch that constitutional democracies have always managed: slow constitutions, fast legislation, faster executive action — each constrained by the layer above. The 6‑Pack replicates this for AI governance. The Assembly does not approve each model update; it sets the terms under which updates are permitted. When those terms are violated, the brakes are already wired.
 
-Indeed, if a "civic" solution only works when your allies run it, it's not civic—it's partisan. True civic infrastructure remains robust even when operated by your opponents.
+In practice, Taiwan moved from Assembly to enacted legislation on deepfake scams in months — faster than most corporate policy cycles. Deliberation is slow only when it is treated as an event rather than standing infrastructure.
 
-Exit rights and portability matters: The ultimate check on agenda-pushing is the ability to leave. When data and relationships are portable, no one can capture a community under the banner of "civic good." If someone's version of relational health feels coercive, communities can fork the tools and rebuild elsewhere.
+#### Bridging algorithms sound appealing in theory. But what happens when one side is simply wrong — climate denial, anti‑vaccine misinformation, election fraud conspiracies? Doesn't "bridging" grant false equivalence to bad‑faith actors?
 
-Finally, we track bridging metrics, not engagement. Do participants report finding common ground with those they previously disagreed with? Do polarization measures decrease? These are harder to game than likes or shares.
+This is the hardest question about bridging, and the answer must be precise.
+
+Bridging is not "both sides" journalism. It does not treat all claims as equally valid. The framework draws a clear epistemic line between two categories:
+
+**Factual claims are checkable.** Climate science, vaccine efficacy, and election integrity are empirical questions with verifiable answers. The 6‑Pack does not submit facts to a popularity contest. Pack 1's first rule — basic rights first — and its threat model both specify that claims designed to erase someone's basic standing or deny established evidence are recorded but do not set the agenda. False balance is listed as an explicit failure mode with a named fix: "separate facts from values, uphold basic rights, and refuse fake equivalence."
+
+**Value disagreements get bridging.** People can agree that climate change is real and still disagree fiercely about what to do — carbon tax versus cap‑and‑trade, nuclear versus renewables, speed of transition versus economic cost. These are legitimate conflicts where bridging is both appropriate and productive. The bridging algorithm does not average positions; it maps clusters and surfaces proposals that earn cross‑group endorsement. Bad‑faith actors who appeal only to their own faction score low on the bridge index by mathematical definition — they cannot produce cross‑group overlap.
+
+The further structural defence is that expression is not amplification (Pack 5). Anyone can state a position. The recommender is not obligated to amplify it. Bridging‑based ranking (Pack 3) rewards content that increases cross‑group endorsement; content that only inflames a single cluster gets no algorithmic lift. This does not silence anyone — it removes the algorithmic megaphone from those who profit from division.
+
+Taiwan's marriage equality deliberation is instructive. One side argued for individual wedding rights (*hūn*); the other for family kinship structures (*yīn*). They were arguing about different things. The bridging process did not split the difference — it made the structure of the disagreement legible, revealing a path (legalising individual weddings without mandating family kinship) that neither side had seen. That is not false equivalence. It is clarity.
+
+#### You cite Taiwan repeatedly — a small island democracy with high connectivity, social cohesion, and tech literacy. Does any of this transfer to India, Nigeria, Brazil, or the EU at 450 million people?
+
+The honest answer is: the mechanisms transfer; the specifics do not. No one should replicate Taiwan's exact model. The question is whether the structural principles — broad listening, bridging algorithms, adopt‑or‑explain commitments, federated safety, subsidiarity — work in different soils.
+
+Early evidence suggests they do:
+
+- **Japan.** Takahiro Anno crowdsourced a gubernatorial platform using AI sensemaking and Polis‑style deliberation. His "Team Mirai" is now a national party in the Diet, having won over 2.5% of the national vote — in a country with a radically different political culture from Taiwan's.
+- **California.** The Engaged California platform, built for teen social media deliberation, pivoted during the LA wildfires to co‑create recovery plans using AI sensemaking. These plans are now being implemented. The same tools are currently hosting deliberations on government efficiency with state employees.
+- **Global.** Bridging algorithms have been deployed in dozens of countries across six continents. The math is culturally agnostic — it finds cross‑group overlap in whatever language and context it encounters. The outputs are always local.
+
+The framework is designed for scale. Subsidiarity (Pack 6) means each deployment is shaped by its context — the kami belongs to its place, not to Taiwan. Federation (Pack 5) means local deployments share threat intelligence and interoperability standards without requiring a single governance model. The Alignment Assembly format can scale from a neighbourhood to a nation because its democratic legitimacy comes from representative sampling, not total participation — 447 representative citizens deliberated Taiwan's anti‑scam policy for a population of 23 million.
+
+What does not transfer is complacency. Every new context demands fresh attentiveness (Pack 1): who is missing, what power dynamics exist, which local institutions deserve trust and which do not. The framework provides the scaffolding. The community provides the knowledge.
+
+#### Your framework assumes that people trust technology enough to participate. But what about marginalized communities who have been historically surveilled, oppressed, and impoverished by the state and by tech? Why would they trust this?
+
+They shouldn't trust it. Trust is not a prerequisite for Civic AI; it is the *output* of it.
+
+Taiwan's digital democracy did not emerge from a society that inherently trusted its government. It was born in the aftermath of authoritarianism and a severe crisis of public faith (the Sunflower Movement). Public trust stood at 9 percent in 2014. We built these systems precisely because people *did not* trust the institutions or each other.
+
+For marginalized communities who rightfully view technology as an instrument of surveillance and control, parachuting in with tech "solutions" only deepens wounds. Civic AI must prove its value through rigid infrastructure: **Responsibility** (Pack 2) and **Responsiveness** (Pack 4). It must start with the smallest viable bridges — perhaps agreeing on basic facts about local water quality, or coordinating disaster response despite political differences. These are not grand acts of civic faith; they are pragmatic transactions that happen to build a thin layer of procedural trust.
+
+Furthermore, the technology must be localized. Communities must own their own infrastructure. The technology becomes theirs to modify, fork, or compost. This is why we insist on *meronymity* (the ability to participate and verify humanity without revealing one's identity to the state) and *exit rights*. Civic AI does not ask for blind faith; it offers verifiable limits, local ownership, and the structural guarantee that the people closest to the pain have the power to hit the brakes.
+
+Over time, small functional bridges create space for larger ones. Taiwan's journey from 9 percent trust to over 70 percent took years and required that every step be reversible, every decision challengeable, every system possible to switch off. There is no shortcut.
+
+#### Oversight boards, participation officers, escrow funds, eval registries, portability infrastructure — this is expensive. Who pays?
+
+The framing of the question is backwards. The relevant comparison is not "civic AI versus no governance" but "civic AI versus the cost of ungoverned AI."
+
+Taiwan's deepfake investment scams cost citizens millions before the Alignment Assembly intervened. Platform‑driven polarisation erodes institutional trust, which has measurable economic consequences — reduced tax compliance, higher policing costs, lower foreign investment, brain drain. A single algorithmic bias lawsuit can cost a corporation more than a decade of participation officers. The question is not whether we can afford civic governance but whether we can afford to skip it.
+
+That said, the money is real and must come from somewhere. Four sources:
+
+1. **Redirected procurement.** Governments already spend billions on AI systems. Civic procurement does not add cost — it attaches conditions to existing spend. Requiring audits, interoperability, and citizen governance is a procurement specification, not a new budget line.
+2. **Vendor obligations.** Engagement contracts (Pack 2) require pre‑funded remedy escrow and portability compliance as a cost of doing public business. These are analogous to performance bonds in construction — the vendor prices them in, and the public is protected when things go wrong.
+3. **Public infrastructure.** Shared research compute, open‑weight models, and federated safety hubs are public goods funded like other infrastructure — roads, courts, spectrum allocation. The marginal cost of adding a civic AI layer to existing digital public infrastructure is modest compared to building from scratch.
+4. **Efficiency gains.** Participation officers are cheaper than the PR crises, lawsuits, and policy reversals they prevent. Bridging‑based deliberation resolves disputes faster than adversarial litigation. Taiwan's Uber dispute was resolved in three weeks through Polis; traditional regulatory proceedings would have taken years.
+
+The expensive path is the one we are currently on: privatised governance, externalised harms, and retroactive clean‑up at public expense.
+
+#### Every governance framework risks becoming a compliance checklist that gets gamed, or a tool for actors to push partisan agendas under the guise of "relational health." What stops the 6‑Pack from suffering this fate?
+
+"Civic" is a dangerous word if it lacks structural accountability. If a solution only works when your ideological allies operate it, it is not civic infrastructure — it is a partisan weapon. The test of true civic infrastructure is that it remains robust and fair even when operated by your opponents.
+
+The 6‑Pack builds in four layers of defence against ideological capture and ethics‑washing:
+
+**1. Verifiable metrics over subjective intent.** We track cross‑group endorsement and trust‑under‑loss (Pack 3) — not raw engagement, not corporate sentiment, not vibes. Do participants on opposing sides both rate the process as fair? Do people who *lost* a decision still accept the outcome as legitimate? These metrics are incredibly hard to fake, because they require buy‑in from people who have reason to be hostile. If only your supporters report trust, the metric exposes you.
+
+**2. Consequences with teeth.** Pack 2's engagement contracts are not aspirational — they carry escrowed funds, automatic payouts on SLA breaches, and independent oversight with veto power. Clawbacks and penalties are wired before launch, not negotiated after failure. A compliance checklist has no enforcement mechanism; an engagement contract has a named owner, a clock, and money on the line.
+
+**3. Adversarial audit.** Pack 4's Weval registries let affected communities author their own evaluations. These are not lab‑designed benchmarks that vendors can "teach to the test" — they are living, community‑maintained test suites. When a community submits a translation‑fidelity eval and the system fails, the pause trigger fires automatically.
+
+**4. Exit rights and subsidiarity.** The ultimate check on agenda‑pushing is the ability to leave. When data and relationships are portable (Pack 5), no actor can hold a community hostage under the banner of "civic good." If someone's version of relational health feels coercive, communities have the technical and legal right to fork the tools and rebuild elsewhere. We refuse to build a single, global "Ministry of Relational Health." By empowering local communities to author their evaluations and retaining their unalienable right to exit, we ensure no single actor can monopolise the definition of what is good.


### PR DESCRIPTION
## Summary

Rewrites Chapter 7 (FAQ) with sharper questions, deeper answers, and new entries.

### What changed

- **Rewritten questions** — more pointed and challenging, removing the interview-style `Question:/Answer:` format
- **Deeper answers** — with specific mechanisms, policy examples, and Pack references woven throughout
- **4 new FAQs added:**
  - Care ethics scaling (turns supposed weaknesses into design features: parochialism→boundedness, self-effacement→corrigibility, intimacy→subsidiarity)
  - Deliberation speed mismatch (two-lane model: slow constitutional guardrails + fast operation within them)
  - Bridging vs false equivalence (epistemic line between factual claims and value disagreements)
  - Cost and funding (four funding sources, reframed as "cost of ungoverned AI")
- **Strengthened existing answers:**
  - Arms-race answer: 5 concrete levers with specific examples (Utah Digital Choice Act, Taiwan tax-filing, civic procurement)
  - Trust answer: Taiwan's 9%→70% trust journey, meronymity, exit rights
  - Agenda-pushing answer: 4 structural defences (verifiable metrics, escrowed consequences, adversarial audit, exit rights)

### Stats
```
1 file changed, 93 insertions(+), 26 deletions(-)
```