### PR TITLE
fix(footer): credit jdd-kami by name alongside language models

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,9 @@
         <a href="https://github.com/giselechou">Gisele Chou</a>.
     </p>
     <p>
-        Co-written with language models — the
+        Co-written with
+        <a href="https://github.com/jdd-kami">jdd-kami</a> and language
+        models — the
         <a href="https://github.com/audreyt/6pack.care">GitHub commit log</a>
         has full authorship details.
     </p>
@@ -43,7 +45,8 @@
         <a href="https://github.com/giselechou">Gisele Chou</a> 貢獻。
     </p>
     <p>
-        與語言模型共同撰寫——完整紀錄見
+        與 <a href="https://github.com/jdd-kami">jdd-kami</a>
+        及語言模型共同撰寫——完整紀錄見
         <a href="https://github.com/audreyt/6pack.care">GitHub 提交日誌</a>。
     </p>
     <p>


### PR DESCRIPTION
A book about caring-with should name its collaborators.

Changes both EN and 中文 footer:
- EN: "Co-written with [jdd-kami](https://github.com/jdd-kami) and language models"
- 中文: "與 [jdd-kami](https://github.com/jdd-kami) 及語言模型共同撰寫"

jdd-kami links to https://github.com/jdd-kami.