### PR TITLE
fix(footer): link 'commit log' to /commits/main/

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,9 @@
         Co-written with
         <a href="https://github.com/jdd-kami">jdd-kami</a> and language models —
         the
-        <a href="https://github.com/audreyt/6pack.care">GitHub commit log</a>
+        <a href="https://github.com/audreyt/6pack.care/commits/main/"
+            >GitHub commit log</a
+        >
         has full authorship details.
     </p>
     <p>
@@ -47,7 +49,9 @@
     <p>
         與 <a href="https://github.com/jdd-kami">jdd-kami</a>
         及語言模型共同撰寫——完整紀錄見
-        <a href="https://github.com/audreyt/6pack.care">GitHub 提交日誌</a>。
+        <a href="https://github.com/audreyt/6pack.care/commits/main/"
+            >GitHub 提交日誌</a
+        >。
     </p>
     <p>
         隸屬<a href="https://afp.oxford-aiethics.ox.ac.uk/">加速哲人計畫</a>，<a


### PR DESCRIPTION
The footer text says 'GitHub commit log' / 'GitHub 提交日誌', so the link should point to the actual commit history at `/commits/main/` instead of the repo root.