### PR TITLE
style: prevent line-break in h1 title

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,9 +38,9 @@
                 {% endif %}
             </div>
             <h1>
-                {{ header_title | default: title }}
-                <span style="font-weight: 300">—</span> {{ subtitle | default:
-                "Institute for Ethics in AI" }}
+                <span style="white-space: nowrap">{{ header_title | default: title }}</span>
+                <span style="font-weight: 300">—</span>
+                <span style="white-space: nowrap">{{ subtitle | default: "Institute for Ethics in AI" }}</span>
             </h1>
             {% if description %}
             <p>{{ description }}</p>


### PR DESCRIPTION
在首頁大標題的左右兩邊加上 `white-space: nowrap`，避免 '6-Pack of Care' 或 'Institute for Ethics in AI'（以及中文版 '關懷六力' / 'AI 倫理研究院'）在中途斷行。

破折號處仍可自然換行。