### PR TITLE
Add live.tec.mx video embed for Ciudadanía Digital keynote

### DIFF
--- a/ciudadania-digital.md
+++ b/ciudadania-digital.md
@@ -12,6 +12,8 @@ nav_next:
     text: "Home"
 ---
 
+<div style="padding:56.25% 0 0 0;position:relative;margin-bottom:2em"><iframe src="https://embed.vhx.tv/videos/3949343" style="position:absolute;top:0;left:0;width:100%;height:100%" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe></div>
+
 Thank you, Paulina. And thank you for 50 years.
 
 That number matters to me. Fifty years ago, the people who built this campus trusted that whoever came after would carry it forward. They could not have imagined our world today: brewing global conflict, extreme weather events, societal polarisation and AI — a technology sophisticated enough to forge fiction into fact.


### PR DESCRIPTION
## Summary
- Adds responsive video embed from [live.tec.mx](https://live.tec.mx/videos/ciudadania-digital-audrey-tang) at the top of the Ciudadanía Digital keynote transcript
- Embed source: `https://embed.vhx.tv/videos/3949343` (VHX/Vimeo OTT)
- Uses 16:9 responsive wrapper for proper scaling

## Test plan
- [ ] Verify embed renders correctly on the site
- [ ] Check responsive behavior on mobile
- [ ] Confirm video plays without authentication issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)